### PR TITLE
Relational field types got renamed in Pimcore

### DIFF
--- a/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Relations.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Relations.php
@@ -132,7 +132,7 @@ class Relations implements LevelDefinitionInterface
 
     public static function getCompatibleFields(ClassDefinition $class)
     {
-        $compatible = ['objects', 'href'];
+        $compatible = ['objects', 'href', 'manyToManyObjectRelation', 'manyToOneRelation'];
         $list = [];
 
         foreach ($class->getFieldDefinitions() as $field) {


### PR DESCRIPTION
Field type "object" got renamed to "manyToManyObjectRelation", 
"href" got renamed to "manyToOneRelation"