### PR TITLE
Routing improvements

### DIFF
--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Controller/AdminController.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Controller/AdminController.php
@@ -37,14 +37,14 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/admin/elements-alternate-object-trees/admin")
+ * @Route("/admin/elements-alternate-object-trees")
  */
 class AdminController extends DataObjectHelperController
 {
     /**
      * get a list of all defined trees
      *
-     * @Route("/get-alternate-object-trees")
+     * @Route("/alternate-object-trees", methods={"GET"})
      */
     public function getAlternateObjectTreesAction(Request $request)
     {
@@ -90,13 +90,13 @@ class AdminController extends DataObjectHelperController
             $return[] = $config;
         }
 
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
      * create new tree
      *
-     * @Route("/add-alternate-object-tree")
+     * @Route("/alternate-object-tree", methods={"POST"})
      */
     public function addAlternateObjectTreeAction(Request $request)
     {
@@ -121,13 +121,13 @@ class AdminController extends DataObjectHelperController
             'id' => $tree->getId()
         ];
 
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
      * delete a tree
      *
-     * @Route("/delete-alternate-object-tree")
+     * @Route("/alternate-object-tree", methods={"DELETE"})
      */
     public function deleteAlternateObjectTreeAction(Request $request)
     {
@@ -147,13 +147,13 @@ class AdminController extends DataObjectHelperController
             'success' => true
         ];
 
-        return $this->json($return);
+        return $this->adminJson($return);
     }
 
     /**
      * get configured tree data
      *
-     * @Route("/get-alternate-object-tree")
+     * @Route("/alternate-object-tree", methods={"GET"})
      */
     public function getAlternateObjectTreeAction(Request $request)
     {
@@ -172,13 +172,13 @@ class AdminController extends DataObjectHelperController
             'levelDefinitions' => json_decode($tree->getJsonLevelDefinitions(), true)
         ];
 
-        return $this->json($config);
+        return $this->adminJson($config);
     }
 
     /**
      * save tree configuration
      *
-     * @Route("/save-alternate-object-tree")
+     * @Route("/alternate-object-tree", methods={"PUT"})
      */
     public function saveAlternateObjectTreeAction(Request $request)
     {
@@ -227,7 +227,7 @@ class AdminController extends DataObjectHelperController
 
         $tree->save();
 
-        return new Response();
+        return $this->adminJson(["success" => true, "id" => $tree->getId()]);
     }
 
     /**
@@ -256,7 +256,7 @@ class AdminController extends DataObjectHelperController
             $fields[] = $field;
         }
 
-        return $this->json($fields);
+        return $this->adminJson($fields);
     }
 
     /**
@@ -334,18 +334,17 @@ class AdminController extends DataObjectHelperController
         }
 
         if ($request->get('limit')) {
-            return $this->json([
+            return $this->adminJson([
                 'total' => $childAmount,
                 'nodes' => $objects
             ]);
         } else {
-            return $this->json($objects);
+            return $this->adminJson($objects);
         }
     }
 
     /**
-     * desc?
-     *
+     * @param Request $request
      * @param Service $service
      * @param $currentLevel
      *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/ElementsAlternateObjectTreesBundle.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/ElementsAlternateObjectTreesBundle.php
@@ -59,6 +59,7 @@ class ElementsAlternateObjectTreesBundle extends AbstractPimcoreBundle
             '/bundles/elementsalternateobjecttrees/js/search.js',
             '/bundles/elementsalternateobjecttrees/js/gridConfigDialog.js',
             '/bundles/elementsalternateobjecttrees/js/config/item.js',
+            '/bundles/elementsalternateobjecttrees/js/config/items.js',
             '/bundles/elementsalternateobjecttrees/js/config/panel.js'
         ];
     }

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/item.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/item.js
@@ -1,7 +1,19 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
 
 pimcore.registerNS("pimcore.plugin.alternateObjectTrees.config.item");
 pimcore.plugin.alternateObjectTrees.config.item = Class.create({
-
 
     initialize: function (data, parentPanel) {
         this.parentPanel = parentPanel;
@@ -211,8 +223,8 @@ pimcore.plugin.alternateObjectTrees.config.item = Class.create({
 
         // save
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/save-alternate-object-tree",
-            method: "post",
+            url: "/admin/elements-alternate-object-trees/alternate-object-tree",
+            method: "PUT",
             params: {
                 settings: Ext.encode(this.settings.getForm().getFieldValues()),
                 levelDefinitions: Ext.encode(levels),
@@ -280,258 +292,3 @@ pimcore.plugin.alternateObjectTrees.config.item = Class.create({
     }
 
 });
-
-
-/** ITEM TYPES **/
-
-pimcore.registerNS("pimcore.plugin.alternateObjectTrees.config.items");
-
-pimcore.plugin.alternateObjectTrees.config.items = {
-
-    detectBlockIndex: function (blockElement, container) {
-        // detect index
-        var index;
-
-        for(var s=0; s<container.items.items.length; s++) {
-            if(container.items.items[s].getId() == blockElement.getId()) {
-                index = s;
-                break;
-            }
-        }
-        return index;
-    },
-
-    getTopBar: function (name, index, parent) {
-        return [{
-            xtype: "tbtext",
-            text: "<b>" + name + "</b>"
-        },"-",{
-            iconCls: "pimcore_icon_up",
-            handler: function (blockId, parent) {
-
-                var container = parent.itemContainer;
-                var blockElement = Ext.getCmp(blockId);
-                var index = pimcore.plugin.alternateObjectTrees.config.items.detectBlockIndex(blockElement, container);
-                var tmpContainer = pimcore.viewport;
-
-                var newIndex = index-1;
-                if(newIndex < 0) {
-                    newIndex = 0;
-                }
-
-                // move this node temorary to an other so ext recognizes a change
-                container.remove(blockElement, false);
-                tmpContainer.add(blockElement);
-                container.updateLayout();
-                tmpContainer.updateLayout();
-
-                // move the element to the right position
-                tmpContainer.remove(blockElement,false);
-                container.insert(newIndex, blockElement);
-                container.updateLayout();
-                tmpContainer.updateLayout();
-
-                pimcore.layout.refresh();
-            }.bind(window, index, parent)
-        },{
-            iconCls: "pimcore_icon_down",
-            handler: function (blockId, parent) {
-
-                var container = parent.itemContainer;
-                var blockElement = Ext.getCmp(blockId);
-                var index = pimcore.settings.thumbnail.items.detectBlockIndex(blockElement, container);
-                var tmpContainer = pimcore.viewport;
-
-                // move this node temorary to an other so ext recognizes a change
-                container.remove(blockElement, false);
-                tmpContainer.add(blockElement);
-                container.updateLayout();
-                tmpContainer.updateLayout();
-
-                // move the element to the right position
-                tmpContainer.remove(blockElement,false);
-                container.insert(index+1, blockElement);
-                container.updateLayout();
-                tmpContainer.updateLayout();
-
-                pimcore.layout.refresh();
-            }.bind(window, index, parent)
-        },"->",{
-            iconCls: "pimcore_icon_delete",
-            handler: function (index, parent) {
-                parent.itemContainer.remove(Ext.getCmp(index));
-            }.bind(window, index, parent)
-        }];
-    },
-
-    /**
-     * handle input type
-     * @param panel
-     * @param data
-     * @param getName
-     * @returns {*}
-     */
-    itemInput: function (panel, data, getName) {
-
-        var niceName = t("plugin_alternate_object_trees_input");
-        if(typeof getName != "undefined" && getName) {
-            return niceName;
-        }
-
-        if(typeof data == "undefined") {
-            data = {};
-        }
-        var myId = Ext.id();
-
-        var item =  new Ext.form.FormPanel({
-            layout: "form",
-            id: myId,
-            type: "input",
-            style: "margin: 10px 0 0 0",
-            bodyStyle: "padding: 10px;",
-            tbar: this.getTopBar(niceName, myId, panel),
-            items: [
-                {
-                    xtype: "combo",
-                    fieldLabel: t("plugin_alternate_object_trees_field"),
-                    name: "fieldname",
-                    width: 400,
-                    store: new Ext.data.JsonStore ({
-                        // store configs
-                        autoDestroy: true,
-                        autoLoad: true,
-                        // baseParams: {
-                        //     type: "input"
-                        // },
-                        proxy: {
-                            type: 'ajax',
-                            url: "/admin/elements-alternate-object-trees/admin/get-valid-fields",
-                            fields: ["name", "title"],
-                            reader: {
-                                type: 'json',
-                                rootProperty: "name"
-                            },
-                            extraParams: {
-                                type: 'input',
-                                name: panel.settings.getForm().findField("o_class").getValue()
-                            }
-                        }
-                    }),
-                    editable: false,
-                    value: data.fieldname,
-                    valueField: 'name',
-                    queryMode: 'remote',
-                    displayField: 'title',
-                    allowBlank: false,
-                    triggerAction: 'all',
-                    listeners: {
-                        select: function(combo, record, index) {
-                            // console.log( panel.settings.getForm().findField("o_class").getValue() );
-                        }
-                    }
-                }, {
-                    xtype: "textarea",
-                    fieldLabel: t("plugin_alternate_object_trees_condition"),
-                    name: "condition",
-                    width: 400,
-                    value: data.condition
-                }, {
-                    xtype: 'textfield',
-                    name: "label",
-                    fieldLabel: t("plugin_alternate_object_trees_label"),
-                    width: 400,
-                    value: data.label
-                }
-            ]
-        });
-
-        return item;
-    },
-
-    /**
-     * handle relation type
-     * @param panel
-     * @param data
-     * @param getName
-     * @returns {*}
-     */
-    itemRelations: function (panel, data, getName) {
-
-        var niceName = t("plugin_alternate_object_trees_relations");
-        if(typeof getName != "undefined" && getName) {
-            return niceName;
-        }
-
-        if(typeof data == "undefined") {
-            data = {};
-        }
-        var myId = Ext.id();
-
-        var item =  new Ext.form.FormPanel({
-            layout: "form",
-            id: myId,
-            type: "relations",
-            style: "margin: 10px 0 0 0",
-            bodyStyle: "padding: 10px;",
-            tbar: this.getTopBar(niceName, myId, panel),
-            items: [
-                {
-                    xtype: "combo",
-                    fieldLabel: t("plugin_alternate_object_trees_field"),
-                    name: "fieldname",
-                    width: 400,
-                    store: new Ext.data.JsonStore ({
-                        // store configs
-                        autoDestroy: true,
-                        autoLoad:true,
-                        proxy: {
-                            url: "/admin/elements-alternate-object-trees/admin/get-valid-fields",
-                            type: 'ajax',
-                            fields: ["name", "title"],
-                            reader: {
-                                type: 'json',
-                                rootProperty: "name"
-                            },
-                            extraParams: {
-                                type: 'relations',
-                                name: panel.settings.getForm().findField("o_class").getValue()
-                            }
-                        }
-                    }),
-                    queryMode: 'remote',
-                    editable: false,
-                    value: data.fieldname,
-                    valueField: 'name',
-                    displayField: 'title',
-                    allowBlank: false,
-                    triggerAction: 'all',
-                    listeners: {
-                        select: function(combo, record, index) {
-                            // console.log( panel.settings.getForm().findField("o_class").getValue() );
-                        }
-                    }
-                }, {
-                    xtype: "textarea",
-                    fieldLabel: t("plugin_alternate_object_trees_condition"),
-                    name: "condition",
-                    width: 400,
-                    value: data.condition
-                }, {
-                    xtype: 'textfield',
-                    name: "label",
-                    fieldLabel: t("plugin_alternate_object_trees_label"),
-                    width: 400,
-                    value: data.label
-                },{
-                    xtype: "checkbox",
-                    name: "showEmpty",
-                    checked: data.showEmpty,
-                    fieldLabel: t("plugin_alternate_object_trees_showEmpty")
-                }
-            ]
-        });
-
-        return item;
-    }
-};
-

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/item.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/item.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/items.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/items.js
@@ -1,0 +1,263 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
+
+pimcore.registerNS("pimcore.plugin.alternateObjectTrees.config.items");
+pimcore.plugin.alternateObjectTrees.config.items = {
+
+    detectBlockIndex: function (blockElement, container) {
+        // detect index
+        var index;
+
+        for(var s=0; s<container.items.items.length; s++) {
+            if(container.items.items[s].getId() == blockElement.getId()) {
+                index = s;
+                break;
+            }
+        }
+        return index;
+    },
+
+    getTopBar: function (name, index, parent) {
+        return [{
+            xtype: "tbtext",
+            text: "<b>" + name + "</b>"
+        },"-",{
+            iconCls: "pimcore_icon_up",
+            handler: function (blockId, parent) {
+
+                var container = parent.itemContainer;
+                var blockElement = Ext.getCmp(blockId);
+                var index = pimcore.plugin.alternateObjectTrees.config.items.detectBlockIndex(blockElement, container);
+                var tmpContainer = pimcore.viewport;
+
+                var newIndex = index-1;
+                if(newIndex < 0) {
+                    newIndex = 0;
+                }
+
+                // move this node temorary to an other so ext recognizes a change
+                container.remove(blockElement, false);
+                tmpContainer.add(blockElement);
+                container.updateLayout();
+                tmpContainer.updateLayout();
+
+                // move the element to the right position
+                tmpContainer.remove(blockElement,false);
+                container.insert(newIndex, blockElement);
+                container.updateLayout();
+                tmpContainer.updateLayout();
+
+                pimcore.layout.refresh();
+            }.bind(window, index, parent)
+        },{
+            iconCls: "pimcore_icon_down",
+            handler: function (blockId, parent) {
+
+                var container = parent.itemContainer;
+                var blockElement = Ext.getCmp(blockId);
+                var index = pimcore.settings.thumbnail.items.detectBlockIndex(blockElement, container);
+                var tmpContainer = pimcore.viewport;
+
+                // move this node temorary to an other so ext recognizes a change
+                container.remove(blockElement, false);
+                tmpContainer.add(blockElement);
+                container.updateLayout();
+                tmpContainer.updateLayout();
+
+                // move the element to the right position
+                tmpContainer.remove(blockElement,false);
+                container.insert(index+1, blockElement);
+                container.updateLayout();
+                tmpContainer.updateLayout();
+
+                pimcore.layout.refresh();
+            }.bind(window, index, parent)
+        },"->",{
+            iconCls: "pimcore_icon_delete",
+            handler: function (index, parent) {
+                parent.itemContainer.remove(Ext.getCmp(index));
+            }.bind(window, index, parent)
+        }];
+    },
+
+    /**
+     * handle input type
+     * @param panel
+     * @param data
+     * @param getName
+     * @returns {*}
+     */
+    itemInput: function (panel, data, getName) {
+
+        var niceName = t("plugin_alternate_object_trees_input");
+        if(typeof getName != "undefined" && getName) {
+            return niceName;
+        }
+
+        if(typeof data == "undefined") {
+            data = {};
+        }
+        var myId = Ext.id();
+
+        var item =  new Ext.form.FormPanel({
+            layout: "form",
+            id: myId,
+            type: "input",
+            style: "margin: 10px 0 0 0",
+            bodyStyle: "padding: 10px;",
+            tbar: this.getTopBar(niceName, myId, panel),
+            items: [
+                {
+                    xtype: "combo",
+                    fieldLabel: t("plugin_alternate_object_trees_field"),
+                    name: "fieldname",
+                    width: 400,
+                    store: new Ext.data.JsonStore ({
+                        // store configs
+                        autoDestroy: true,
+                        autoLoad: true,
+                        // baseParams: {
+                        //     type: "input"
+                        // },
+                        proxy: {
+                            type: 'ajax',
+                            url: "/admin/elements-alternate-object-trees/get-valid-fields",
+                            fields: ["name", "title"],
+                            reader: {
+                                type: 'json',
+                                rootProperty: "name"
+                            },
+                            extraParams: {
+                                type: 'input',
+                                name: panel.settings.getForm().findField("o_class").getValue()
+                            }
+                        }
+                    }),
+                    editable: false,
+                    value: data.fieldname,
+                    valueField: 'name',
+                    queryMode: 'remote',
+                    displayField: 'title',
+                    allowBlank: false,
+                    triggerAction: 'all',
+                    listeners: {
+                        select: function(combo, record, index) {
+                            // console.log( panel.settings.getForm().findField("o_class").getValue() );
+                        }
+                    }
+                }, {
+                    xtype: "textarea",
+                    fieldLabel: t("plugin_alternate_object_trees_condition"),
+                    name: "condition",
+                    width: 400,
+                    value: data.condition
+                }, {
+                    xtype: 'textfield',
+                    name: "label",
+                    fieldLabel: t("plugin_alternate_object_trees_label"),
+                    width: 400,
+                    value: data.label
+                }
+            ]
+        });
+
+        return item;
+    },
+
+    /**
+     * handle relation type
+     * @param panel
+     * @param data
+     * @param getName
+     * @returns {*}
+     */
+    itemRelations: function (panel, data, getName) {
+
+        var niceName = t("plugin_alternate_object_trees_relations");
+        if(typeof getName != "undefined" && getName) {
+            return niceName;
+        }
+
+        if(typeof data == "undefined") {
+            data = {};
+        }
+        var myId = Ext.id();
+
+        var item =  new Ext.form.FormPanel({
+            layout: "form",
+            id: myId,
+            type: "relations",
+            style: "margin: 10px 0 0 0",
+            bodyStyle: "padding: 10px;",
+            tbar: this.getTopBar(niceName, myId, panel),
+            items: [
+                {
+                    xtype: "combo",
+                    fieldLabel: t("plugin_alternate_object_trees_field"),
+                    name: "fieldname",
+                    width: 400,
+                    store: new Ext.data.JsonStore ({
+                        // store configs
+                        autoDestroy: true,
+                        autoLoad:true,
+                        proxy: {
+                            url: "/admin/elements-alternate-object-trees/get-valid-fields",
+                            type: 'ajax',
+                            fields: ["name", "title"],
+                            reader: {
+                                type: 'json',
+                                rootProperty: "name"
+                            },
+                            extraParams: {
+                                type: 'relations',
+                                name: panel.settings.getForm().findField("o_class").getValue()
+                            }
+                        }
+                    }),
+                    queryMode: 'remote',
+                    editable: false,
+                    value: data.fieldname,
+                    valueField: 'name',
+                    displayField: 'title',
+                    allowBlank: false,
+                    triggerAction: 'all',
+                    listeners: {
+                        select: function(combo, record, index) {
+                            // console.log( panel.settings.getForm().findField("o_class").getValue() );
+                        }
+                    }
+                }, {
+                    xtype: "textarea",
+                    fieldLabel: t("plugin_alternate_object_trees_condition"),
+                    name: "condition",
+                    width: 400,
+                    value: data.condition
+                }, {
+                    xtype: 'textfield',
+                    name: "label",
+                    fieldLabel: t("plugin_alternate_object_trees_label"),
+                    width: 400,
+                    value: data.label
+                },{
+                    xtype: "checkbox",
+                    name: "showEmpty",
+                    checked: data.showEmpty,
+                    fieldLabel: t("plugin_alternate_object_trees_showEmpty")
+                }
+            ]
+        });
+
+        return item;
+    }
+};

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/items.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/items.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/panel.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/panel.js
@@ -58,7 +58,7 @@ pimcore.plugin.alternateObjectTrees.config.panel = Class.create({
                 autoSync: false,
                 proxy: {
                     type: 'ajax',
-                    url: '/admin/elements-alternate-object-trees/admin/get-alternate-object-trees',
+                    url: '/admin/elements-alternate-object-trees/alternate-object-trees',
                     reader: {
                         type: 'json'
                     }
@@ -150,7 +150,8 @@ pimcore.plugin.alternateObjectTrees.config.panel = Class.create({
         }
 
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/get-alternate-object-tree",
+            url: "/admin/elements-alternate-object-trees/alternate-object-tree",
+            method: "GET",
             params: {
                 name: id
             },
@@ -199,7 +200,8 @@ pimcore.plugin.alternateObjectTrees.config.panel = Class.create({
             }
 
             Ext.Ajax.request({
-                url: "/admin/elements-alternate-object-trees/admin/add-alternate-object-tree",
+                url: "/admin/elements-alternate-object-trees/admin/alternate-object-tree",
+                method: "POST"
                 params: {
                     name: value
                 },
@@ -227,7 +229,8 @@ pimcore.plugin.alternateObjectTrees.config.panel = Class.create({
 
     deleteField: function (view, model) {
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/delete-alternate-object-tree",
+            url: "/admin/elements-alternate-object-trees/delete-alternate-object-tree",
+            method: "DELETE",
             params: {
                 id: model.get('id')
             }

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/folder.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/folder.js
@@ -1,3 +1,17 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
+
 pimcore.registerNS("pimcore.plugin.alternateObjectTrees.folder");
 pimcore.plugin.alternateObjectTrees.folder = Class.create(pimcore.object.folder, {
     initialize: function(treeId, level, attributeValue) {
@@ -78,7 +92,7 @@ pimcore.plugin.alternateObjectTrees.folder = Class.create(pimcore.object.folder,
     getData: function () {
         var options = this.options || {};
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/grid-get-data",
+            url: "/admin/elements-alternate-object-trees/grid-get-data",
             params: {alternateTreeId: this.treeId, level: this.level, attributeValue: this.attributeValue},
             ignoreErrors: options.ignoreNotFoundError,
             success: this.getDataComplete.bind(this),

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/folder.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/folder.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/gridConfigDialog.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/gridConfigDialog.js
@@ -1,3 +1,17 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
+
 pimcore.registerNS("pimcore.plugin.alternateObjectTrees.gridConfigDialog");
 pimcore.plugin.alternateObjectTrees.gridConfigDialog = Class.create(pimcore.object.helpers.gridConfigDialog, {
     requestPreview: function () {
@@ -12,7 +26,7 @@ pimcore.plugin.alternateObjectTrees.gridConfigDialog = Class.create(pimcore.obje
         }
 
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/grid-proxy?alternateTreeId=" + this.config.treeId + "&level="+this.config.level+"&attributeValue="+this.config.attributeValue,
+            url: "/admin/elements-alternate-object-trees/grid-proxy?alternateTreeId=" + this.config.treeId + "&level="+this.config.level+"&attributeValue="+this.config.attributeValue,
             method: 'POST',
             params: {
                 "fields[]": keys,

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/gridConfigDialog.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/gridConfigDialog.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/plugin.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/plugin.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/plugin.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/plugin.js
@@ -1,7 +1,19 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
+
 pimcore.registerNS("pimcore.plugin.alternateObjectTrees.plugin");
-
-pimcore.plugin.alternateObjectTrees.plugin = Class.create(pimcore.plugin.admin,{
-
+pimcore.plugin.alternateObjectTrees.plugin = Class.create(pimcore.plugin.admin, {
 
     getClassName: function (){
         return "pimcore.plugin.AlternateObjectTrees";
@@ -21,7 +33,7 @@ pimcore.plugin.alternateObjectTrees.plugin = Class.create(pimcore.plugin.admin,{
 
         // load defined trees
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/get-alternate-object-trees",
+            url: "/admin/elements-alternate-object-trees/alternate-object-trees",
             params: {
                 checkValid: 1
             },

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/search.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/search.js
@@ -1,3 +1,17 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
+
 pimcore.registerNS("pimcore.plugin.alternateObjectTrees.search");
 pimcore.plugin.alternateObjectTrees.search = Class.create(pimcore.object.search, {
     createGrid: function (fromConfig, response, settings, save) {
@@ -63,7 +77,7 @@ pimcore.plugin.alternateObjectTrees.search = Class.create(pimcore.object.search,
         var gridHelper = new pimcore.object.helpers.grid(
             klass.data.text,
             fields,
-            "/admin/elements-alternate-object-trees/admin/grid-proxy?alternateTreeId=" + this.object.data.general.treeId + "&level="+this.object.data.general.level+"&attributeValue="+this.object.data.general.attributeValue,
+            "/admin/elements-alternate-object-trees/grid-proxy?alternateTreeId=" + this.object.data.general.treeId + "&level="+this.object.data.general.level+"&attributeValue="+this.object.data.general.attributeValue,
             {
                 language: this.gridLanguage,
                 // limit: itemsPerPage
@@ -444,7 +458,7 @@ pimcore.plugin.alternateObjectTrees.search = Class.create(pimcore.object.search,
 
     getTableDescription: function () {
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/grid-get-column-config",
+            url: "/admin/elements-alternate-object-trees/grid-get-column-config",
             params: {
                 id: this.object.id,
                 alternateTreeId: this.object.data.general.treeId,
@@ -466,7 +480,7 @@ pimcore.plugin.alternateObjectTrees.search = Class.create(pimcore.object.search,
             };
 
             Ext.Ajax.request({
-                url: '/admin/elements-alternate-object-trees/admin/grid-save-column-config',
+                url: '/admin/elements-alternate-object-trees/grid-save-column-config',
                 method: "post",
                 params: data,
                 success: function (response) {
@@ -547,7 +561,7 @@ pimcore.plugin.alternateObjectTrees.search = Class.create(pimcore.object.search,
 
 
         Ext.Ajax.request({
-            url: "/admin/elements-alternate-object-trees/admin/get-export-jobs",
+            url: "/admin/elements-alternate-object-trees/get-export-jobs",
             params: params,
             success: function (response) {
                 var rdata = Ext.decode(response.responseText);

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/search.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/search.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/tree.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/tree.js
@@ -1,7 +1,21 @@
+/**
+ * Pimcore
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.pimcore.org/license
+ *
+ * @copyright  Copyright (c) 2009-2010 elements.at New Media Solutions GmbH (http://www.elements.at)
+ * @license    http://www.pimcore.org/license     New BSD License
+ */
+
 pimcore.registerNS("pimcore.plugin.alternateObjectTrees.tree");
 pimcore.plugin.alternateObjectTrees.tree = Class.create(pimcore.object.tree, {
 
-    treeDataUrl: "/admin/elements-alternate-object-trees/admin/tree-get-children-by-id",
+    treeDataUrl: "/admin/elements-alternate-object-trees/tree-get-children-by-id",
 
     initialize: function(config) {
 

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/tree.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/tree.js
@@ -1,5 +1,5 @@
 /**
- * Pimcore
+ * Elements.at
  *
  * LICENSE
  *


### PR DESCRIPTION
Hi!

1. Removed extra "admin" in bundle routing (was /admin/elements-alternate-object-trees/*admin*/tree-get-children-by-id, after /admin/elements-alternate-object-trees/tree-get-children-by-id)
2. For get/update/save action routing is updated to  /alternate-object-tree and added methods (GET, POST, PUT, DELETE) - like as REST.
3. Responses are updated to adminJson, for use Admin serializer
4. For /save-alternate-object-tree is changed response from empty to {"success": true, "id": <id of new object>}
5. Split Javascript for item and items to 2 files instead 1
6. Small consistency fixes: removed extra spaces, copyrights, PHPDoc params/return.

I hope, it`ll be helpful.
Thnx!