### PR TITLE
Added icon with white flat icon for Pimcore 6 theme

### DIFF
--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/css/icons.css
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/css/icons.css
@@ -3,3 +3,7 @@
 .plugin_alternate_object_trees_config {
     background: url(/bundles/pimcoreadmin/img/flat-color-icons/flow_chart.svg) left center no-repeat !important;
 }
+
+body.pimcore_version_6 .plugin_alternate_object_trees {
+    background-image: url(/bundles/pimcoreadmin/img/flat-white-icons/flow_chart.svg) !important;
+}

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/panel.js
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/public/js/config/panel.js
@@ -30,7 +30,7 @@ pimcore.plugin.alternateObjectTrees.config.panel = Class.create({
             this.panel = new Ext.Panel({
                 id: "plugin_alternate_object_trees_config",
                 title: t("plugin_alternate_object_trees_config"),
-                iconCls: "plugin_alternate_object_trees",
+                iconCls: "plugin_alternate_object_trees_config",
                 border: false,
                 layout: "border",
                 closable: true,


### PR DESCRIPTION
Added custom styling for Pimcore 6.x with white flat icon:

<img width="577" alt="Screenshot at Jan 20 10-01-46" src="https://user-images.githubusercontent.com/5318027/72705258-13a04a00-3b6c-11ea-9aec-6d77f210debe.png">
