### PR TITLE
Pimcore 6.5.0 compatibility

### DIFF
--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Controller/AdminController.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Controller/AdminController.php
@@ -644,10 +644,11 @@ class AdminController extends DataObjectHelperController
      * @Route("/grid-get-column-config", methods={"GET"})
      *
      * @param Request $request
+     * @param \Pimcore\Config $config
      *
      * @return JsonResponse
      */
-    public function gridGetColumnConfigAction(Request $request)
+    public function gridGetColumnConfigAction(Request $request, \Pimcore\Config $config)
     {
         $isDelete = false;
         $tree = null;
@@ -883,8 +884,7 @@ class AdminController extends DataObjectHelperController
             return ($a['position'] < $b['position']) ? -1 : 1;
         });
 
-        $config = \Pimcore\Config::getSystemConfig();
-        $frontendLanguages = Admin::reorderWebsiteLanguages(Admin::getCurrentUser(), $config->general->validLanguages);
+        $frontendLanguages = Admin::reorderWebsiteLanguages(Admin::getCurrentUser(), $config['general']['valid_languages']);
         if ($frontendLanguages) {
             $language = explode(',', $frontendLanguages)[0];
         } else {


### PR DESCRIPTION
In Pimcore 6.5.0 Changelogs (more detailed in Pimcore 6.5.2) was introduced changes for \Pimcore\Config and AdminCore controller has been updated in PR [#5745](ttps://github.com/pimcore/pimcore/pull/5745).

I've added fix for Controller, but I have question about Composer requirement and new version - Looks as new Config service doesn't work in Pimcore 5 or before 6.5 - So, What version are you prefer:
1) 2.2.0 with composer require pimcore/pimcore:^6.5
2) 3.0.0 with composer require pimcore/pimcore:^6.5
3) next version and I can add check to implementsArrayAccess and convert object to Array  for previous versions? 

Please review,
Thnx