### PR TITLE
Attribute with value of '0' not filtered

### DIFF
--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Controller/AdminController.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Controller/AdminController.php
@@ -297,8 +297,9 @@ class AdminController extends DataObjectHelperController
 
                 $objects = $levelConfig['list'];
 
+                $attributeValue = $request->get('attributeValue');
                 foreach ($objects as &$object) {
-                    if ($request->get('attributeValue')) {
+                    if (!empty($attributeValue) || $attributeValue === '0') {      // test for '0'
                         $filterValues[$level] = $request->get('attributeValue');
                     }
                     $object['filterValues'] = $filterValues;

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/config/pimcore/routing.yml
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/Resources/config/pimcore/routing.yml
@@ -1,3 +1,5 @@
 _elements_alternate_object_trees:
     resource: "@ElementsAlternateObjectTreesBundle/Controller/"
     type:     annotation
+    options:
+        expose: true


### PR DESCRIPTION
In AdminController.php filterValues is not correct if the attribute value is '0', such as with a checkbox. Add a test for this in function treeGetChildrenByIdAction().